### PR TITLE
Format http log

### DIFF
--- a/appcatalog/frontendUpload.go
+++ b/appcatalog/frontendUpload.go
@@ -47,7 +47,7 @@ func UploadToFrontend(uploadURI string, zapFile string, appName string, sessionI
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		log.Println("Error reading response from the fronted.")
+		log.Println("Error reading response from the frontend.")
 		return "", err
 	}
 

--- a/appcatalog/logServerResponse.go
+++ b/appcatalog/logServerResponse.go
@@ -3,17 +3,19 @@ package appcatalog
 import (
 	"log"
 	"net/http"
+	"sort"
 )
 
 func logServerResponse(res *http.Response) {
-	log.Printf("Server response: %s\n", res.Request.URL)
-	logHeaders(res)
-}
-
-func logHeaders(res *http.Response) {
-	log.Println("\tHeaders:")
-	for k, v := range res.Header {
-		log.Printf("\t%s: %s\n", k, v)
+	log.Printf("\t%s %s\n", res.Request.Method, res.Request.URL)
+	log.Printf("\t%s %s\n", res.Proto, res.Status)
+	keys := make([]string, 0, len(res.Header))
+	for k := range res.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		log.Printf("\t%s: %s\n", k, res.Header.Get(k))
 	}
 	log.Println("")
 }


### PR DESCRIPTION
Sort headers and format http log to be similar to HTTP body spec.

![schermafbeelding 2016-12-22 om 10 05 10](https://cloud.githubusercontent.com/assets/1031418/21420473/3b618a54-c82e-11e6-8ce5-56f2943162bf.png)
