### PR TITLE
feature: pre push stages.

### DIFF
--- a/push.go
+++ b/push.go
@@ -25,13 +25,14 @@ func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalAr
 	var (
 		appPath       string // path to the App folder
 		noBrowser     bool   // skip opening the site in the browser
+		noVerify      bool   // skip the tests
 		waitInSeconds int    // polling timeout
 		localFrontend bool   // true if we open the local frontend instead of the dev server
 	)
 
 	command := app.Command("push", "Push the App in the specified folder.").
 		Action(func(parseContext *kingpin.ParseContext) error {
-			return push(config, appPath, noBrowser, waitInSeconds, localFrontend, args)
+			return push(config, appPath, noBrowser, noVerify, waitInSeconds, localFrontend, args)
 		})
 
 	command.Arg("appPath", "path to the App folder (default: current folder).").
@@ -42,6 +43,10 @@ func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalAr
 		Default("false").
 		BoolVar(&noBrowser)
 
+	command.Flag("noVerify", "Appix won't run the tests.").
+		Default("false").
+		BoolVar(&noVerify)
+
 	command.Flag("wait", "The maximum time appix waits for the app bundling to be finished.").
 		Short('w').
 		Default("180").
@@ -51,8 +56,8 @@ func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalAr
 		BoolVar(&localFrontend)
 }
 
-func push(config config.Config, appPath string, noBrowser bool, wait int, localFrontend bool, args *GlobalArgs) error {
-	appPath, appName, appManifestFile, err := prepareAppUpload(appPath)
+func push(config config.Config, appPath string, noBrowser bool, noVerify bool, wait int, localFrontend bool, args *GlobalArgs) error {
+	appPath, appName, appManifestFile, err := prepareAppUpload(appPath, noVerify)
 
 	if err != nil {
 		log.Println("Could not prepare the app folder for uploading")

--- a/stages.go
+++ b/stages.go
@@ -1,0 +1,85 @@
+package appix
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Stage : the structure representing the data model for using stages
+type Stage struct {
+	Name string `json:"name"`
+	Cmd  string `json:"cmd"`
+}
+
+var pool chan bool
+var wg sync.WaitGroup
+
+// startStage : executes the command for the given kind of test
+func startStage(name string, cmd string) {
+	defer wg.Done()
+	// format the command in order to use os/exec/Command
+	firstSpace := strings.Index(cmd, " ")
+
+	var command string
+	var args []string
+
+	if firstSpace > 0 {
+		command = cmd[:firstSpace]
+		args = strings.Split(cmd[firstSpace:len(cmd)], " ")
+	} else {
+		command = cmd
+	}
+
+	cm := exec.Command(command)
+
+	if len(args) > 0 {
+		cm.Args = args
+	}
+
+	// define and set an output buffer.
+	// TODO: do we display the logs all the time or do we consider --verbose as a flag?
+	var out bytes.Buffer
+	cm.Stdout = &out
+
+	// execute the command
+	err := cm.Run()
+
+	if err != nil {
+		log.Printf("The stage '%s' failed: %s\n", name, err.Error())
+		pool <- false
+		return
+	}
+	log.Printf("Stage '%s' done.", name)
+	pool <- true
+}
+
+// CreateStagePool : create the pool of stage. Each stage must be independent since there is no synchronisation between the routines
+func CreateStagePool(stages []Stage) chan bool {
+	pool = make(chan bool, len(stages))
+	wg.Add(len(stages))
+
+	// the routine taking care of the result set in the pool
+	go func() error {
+		for status := range pool {
+			if !status {
+				return errors.New("An error occured")
+			}
+		}
+		return nil
+	}()
+
+	// fill the pool
+	for _, s := range stages {
+		go startStage(s.Name, s.Cmd)
+	}
+
+	// close
+	wg.Wait()
+	close(pool)
+
+	return pool
+}

--- a/stages_test.go
+++ b/stages_test.go
@@ -1,0 +1,77 @@
+package appix
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+func TestCreateStagePoolSuccessCase(t *testing.T) {
+	var cmds []Stage
+
+	// execute "go version". Supposed to work across all-platform
+	for i := 0; i < 10; i++ {
+		cmds = append(cmds, Stage{
+			Cmd:  "go version",
+			Name: fmt.Sprintf("command #%d", i),
+		})
+	}
+
+	failed := <-CreateStagePool(cmds)
+
+	if failed {
+		t.Errorf("An error happened while running the commands")
+		t.FailNow()
+	} else {
+		log.Printf("The test passed successfully")
+	}
+}
+
+func TestCreateStagePoolFailCase(t *testing.T) {
+	var cmds []Stage
+
+	// append fake command to generate a fail
+	cmds = append(cmds, Stage{
+		Cmd:  "fakeCommand version",
+		Name: "failing command",
+	})
+
+	for i := 0; i < 10; i++ {
+		cmds = append(cmds, Stage{
+			Cmd:  "go version",
+			Name: fmt.Sprintf("command #%d", i),
+		})
+	}
+
+	failed := <-CreateStagePool(cmds)
+
+	if failed {
+		log.Printf("The test passed successfully")
+	} else {
+		t.Errorf("An error happened while running the commands")
+		t.FailNow()
+	}
+}
+
+func BenchmarkStagePool(b *testing.B) {
+	var cmds []Stage
+
+	// execute "go version". Supposed to work across all-platform
+	for i := 0; i < 10; i++ {
+		cmds = append(cmds, Stage{
+			Cmd:  "go version",
+			Name: fmt.Sprintf("command #%d", i),
+		})
+	}
+
+	for i := 0; i < 10; i++ {
+		failed := <-CreateStagePool(cmds)
+
+		if failed {
+			b.Errorf("An error happened while running the commands")
+			b.FailNow()
+		} else {
+			log.Printf("The test passed successfully")
+		}
+	}
+}

--- a/submit.go
+++ b/submit.go
@@ -14,7 +14,10 @@ import (
 func RegisterSubmit(app *kingpin.Application, config config.Config, args *GlobalArgs) {
 	const submitTemplateURI = "%s/files/publish/%s"
 
-	var appPath string // path to the App folder
+	var (
+		appPath  string // path to the App folder
+		noVerify bool
+	)
 
 	command := app.Command("submit", "Submits the App for review.").
 		Action(func(parseContext *kingpin.ParseContext) error {
@@ -24,7 +27,7 @@ func RegisterSubmit(app *kingpin.Application, config config.Config, args *Global
 				environment = "dev"
 			}
 
-			appPath, appName, appManifestFile, err := prepareAppUpload(appPath)
+			appPath, appName, appManifestFile, err := prepareAppUpload(appPath, noVerify)
 
 			if err != nil {
 				log.Println("Could not prepare the app folder for uploading")
@@ -62,4 +65,8 @@ func RegisterSubmit(app *kingpin.Application, config config.Config, args *Global
 	command.Arg("appPath", "path to the App folder (default: current folder)").
 		Default(".").
 		ExistingDirVar(&appPath)
+
+	command.Flag("noVerify", "Appix won't run the tests.").
+		Default("false").
+		BoolVar(&noVerify)
 }


### PR DESCRIPTION
Do

The pull request add two new properties to the app.manifest.

tests:
Representation:

```
 {
  /* ... your stuff */
  "tests": [
    {
       "name": "unit-tests",
       "cmd": "npm run tests"
    }
  ]
  /* ... your other stuff */
 }
```

The property "tests" is an array of Stage. Each Stage must be independent. The stage are ran in parallel before "zappification" of the widget.

If one fail it kills the command executed (push, watch ...)

If for any reasons the tests must be skipped the push, watch, submit commands are now having a new flag `--noVerify`

Usage: `$> appix push --noVerify .`

build:
Representation:


```
 {
  /* ... your stuff */
  "build": [
    {
       "name": "bundle-ts",
       "cmd": "tsc *.ts"
    }
  ]
  /* ... your other stuff */
 }
```

Such as the tests, the build is an array of independent stages. They are ran at the same time.

TO-THINK How to sandbox the build scripts?