### PR TITLE
Changes IgnoreFilePath to ignore files and/or folders that contain the ignoredFileName in it

### DIFF
--- a/ignore.go
+++ b/ignore.go
@@ -37,6 +37,9 @@ func IgnoreFilePath(path string) (ignored bool, ignoredFolder bool) {
 			if strings.EqualFold(fileName, ignoredFileName) {
 				ignored = true
 				break
+			} else if strings.Contains(fileName, ignoredFileName) {
+				ignored = true
+				break
 			}
 		}
 

--- a/ignore.go
+++ b/ignore.go
@@ -23,33 +23,25 @@ var ignoredFileNames = []string{
 }
 
 func IgnoreFilePath(path string) (ignored bool, ignoredFolder bool) {
-	var recurse func(string) (bool, bool)
-	recurse = func(path string) (ignored bool, ignoredFolder bool) {
-		fileName := filepath.Base(path)
+	fileName := filepath.Base(path)
+	dir := filepath.Dir(path)
 
-		if fileName == "." {
-			ignored = false
-			ignoredFolder = false
-			return
-		}
-
-		for _, ignoredFileName := range ignoredFileNames {
-			if strings.EqualFold(fileName, ignoredFileName) {
-				ignored = true
-				break
-			} else if strings.Contains(fileName, ignoredFileName) {
-				ignored = true
-				break
-			}
-		}
-
-		dir := filepath.Dir(path)
-		ignoredFolder, _ = recurse(dir)
-		ignored = ignored || ignoredFolder
+	if fileName == "." {
+		ignored = false
+		ignoredFolder = false
 		return
 	}
 
-	ignored, ignoredFolder = recurse(path)
+	for _, ignoredFileName := range ignoredFileNames {
+		if strings.EqualFold(fileName, ignoredFileName) {
+			ignored = true
+			break
+		} else if strings.Contains(dir, ignoredFileName + string(os.PathSeparator)) {
+			ignoredFolder = true
+			break
+		}
+	}
+
 	return
 }
 

--- a/ignore.go
+++ b/ignore.go
@@ -9,11 +9,11 @@ import (
 )
 
 var ignoredFileNames = []string{
-	"node_modules",
-	"temp",
-	".git",
-	".idea",
-	".vscode",
+	"node_modules/*",
+	"temp/*",
+	".git/*",
+	".idea/*",
+	".vscode/*",
 	".ds_store",
 	"thumbs.db",
 	"desktop.ini",

--- a/ignore.go
+++ b/ignore.go
@@ -36,7 +36,10 @@ func IgnoreFilePath(path string) (ignored bool, ignoredFolder bool) {
 		if strings.EqualFold(fileName, ignoredFileName) {
 			ignored = true
 			break
-		} else if strings.Contains(dir, ignoredFileName + string(os.PathSeparator)) {
+		}
+
+		dirPrefix := ignoredFileName + string(os.PathSeparator)
+		if strings.HasPrefix(dir, dirPrefix) || strings.Contains(dir, string(os.PathSeparator) + dirPrefix) {
 			ignoredFolder = true
 			break
 		}

--- a/ignore.go
+++ b/ignore.go
@@ -4,8 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"strings"
-
+	"github.com/ryanuber/go-glob"
 	"github.com/Travix-International/appix/config"
 )
 
@@ -22,25 +21,17 @@ var ignoredFileNames = []string{
 	config.IgnoreFileName,
 }
 
-func IgnoreFilePath(path string) (ignored bool, ignoredFolder bool) {
+func IgnoreFilePath(path string) (ignored bool) {
 	fileName := filepath.Base(path)
-	dir := filepath.Dir(path)
 
 	if fileName == "." {
 		ignored = false
-		ignoredFolder = false
 		return
 	}
 
 	for _, ignoredFileName := range ignoredFileNames {
-		if strings.EqualFold(fileName, ignoredFileName) {
+		if glob.Glob(ignoredFileName, path) {
 			ignored = true
-			break
-		}
-
-		dirPrefix := ignoredFileName + string(os.PathSeparator)
-		if strings.HasPrefix(dir, dirPrefix) || strings.Contains(dir, string(os.PathSeparator) + dirPrefix) {
-			ignoredFolder = true
 			break
 		}
 	}

--- a/vendor/github.com/ryanuber/go-glob/LICENSE
+++ b/vendor/github.com/ryanuber/go-glob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ryan Uber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ryanuber/go-glob/glob.go
+++ b/vendor/github.com/ryanuber/go-glob/glob.go
@@ -1,0 +1,56 @@
+package glob
+
+import "strings"
+
+// The character which is treated like a glob
+const GLOB = "*"
+
+// Glob will test a string pattern, potentially containing globs, against a
+// subject string. The result is a simple true/false, determining whether or
+// not the glob pattern matched the subject text.
+func Glob(pattern, subj string) bool {
+	// Empty pattern can only match empty subject
+	if pattern == "" {
+		return subj == pattern
+	}
+
+	// If the pattern _is_ a glob, it matches everything
+	if pattern == GLOB {
+		return true
+	}
+
+	parts := strings.Split(pattern, GLOB)
+
+	if len(parts) == 1 {
+		// No globs in pattern, so test for equality
+		return subj == pattern
+	}
+
+	leadingGlob := strings.HasPrefix(pattern, GLOB)
+	trailingGlob := strings.HasSuffix(pattern, GLOB)
+	end := len(parts) - 1
+
+	// Go over the leading parts and ensure they match.
+	for i := 0; i < end; i++ {
+		idx := strings.Index(subj, parts[i])
+
+		switch i {
+		case 0:
+			// Check the first section. Requires special handling.
+			if !leadingGlob && idx != 0 {
+				return false
+			}
+		default:
+			// Check that the middle parts match.
+			if idx < 0 {
+				return false
+			}
+		}
+
+		// Trim evaluated text from subj as we loop over the pattern.
+		subj = subj[idx+len(parts[i]):]
+	}
+
+	// Reached the last section. Requires special handling.
+	return trailingGlob || strings.HasSuffix(subj, parts[end])
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -74,6 +74,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/ryanuber/go-glob",
+			"repository": "https://github.com/ryanuber/go-glob",
+			"vcs": "git",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/sergi/go-diff/diffmatchpatch",
 			"repository": "https://github.com/sergi/go-diff",
 			"vcs": "git",

--- a/watch.go
+++ b/watch.go
@@ -92,8 +92,8 @@ func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalA
 					relPath := strings.TrimPrefix(filePath, absPath)
 					relPath = strings.TrimLeft(relPath, string(os.PathSeparator))
 
-					if ignored, ignoredFolder := IgnoreFilePath(relPath); ignored {
-						if args.Verbose && !ignoredFolder {
+					if ignored:= IgnoreFilePath(relPath); ignored {
+						if args.Verbose {
 							log.Println("Ignoring file changes:", filePath)
 						}
 						break

--- a/watch.go
+++ b/watch.go
@@ -93,7 +93,8 @@ func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalA
 					relPath = strings.TrimLeft(relPath, string(os.PathSeparator))
 
 					if ignored:= IgnoreFilePath(relPath); ignored {
-						if args.Verbose {
+						ignoredFolder := IgnoreFilePath(filepath.Dir(relPath));
+						if args.Verbose && !ignoredFolder {
 							log.Println("Ignoring file changes:", filePath)
 						}
 						break

--- a/zapper.go
+++ b/zapper.go
@@ -73,8 +73,8 @@ func createZapPackage(appPath string, verbose bool) (string, error) {
 	}
 
 	err = zipFolder(appPath, zapFile, func(path string) bool {
-		ignored, ignoredFolder := IgnoreFilePath(path)
-		if verbose && !ignoredFolder {
+		ignored := IgnoreFilePath(path)
+		if verbose {
 			if ignored {
 				log.Printf("\tSkipping %s\n", path)
 			} else {


### PR DESCRIPTION
# What does this PR do:

* Changes the `IgnoreFilePath` to ignore files based on glob patterns, adding a new dependency ([go-glob](https://github.com/ryanuber/go-glob)) for that.
* Changes the signature and usage of the above mentioned function to just return the `ignored` value.
* Removes recursion on the function, since it's not needed, IMHO.
* Adds simple glob pattern support for `.appixignore`. E.g: `ui/*.ext`

Attempts to fix #45 

# Where should the reviewer start:
  - Diffs
  - Do `gvt restore`
  - Run the `./build.sh` and use a `.appixignore` to test

_Bear in mind I'm still learning, so, I've probably done something wrong_