### PR TITLE
Fixes clone's destination path on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For developing the ADK itself:
 Clone the repo to your `$GOPATH`:
 
 ```
-$ git clone git@github.com:Travix-International/appix.git $GOPATH/src/Travix-International/appix
+$ git clone git@github.com:Travix-International/appix.git $GOPATH/src/github.com/Travix-International/appix
 ```
 
 ### Dependencies


### PR DESCRIPTION
# What does this PR do:

Fixes #46 issue due to typo in the _Clone_ section in the `README.md`.

# Where should the reviewer start:
  - Diffs