### PR TITLE
TR-11443 Replace the logger instance creation with IoC

### DIFF
--- a/appcatalog/prepare.go
+++ b/appcatalog/prepare.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/Travix-International/appix/appixLogger"
 	"github.com/Travix-International/appix/auth"
 	"github.com/Travix-International/appix/config"
 )
 
-func prepare(uri string, files map[string]string, config config.Config, verbose bool) (req *http.Request, err error) {
+func prepare(uri string, files map[string]string, config config.Config, verbose bool, logger *appixLogger.Logger) (req *http.Request, err error) {
 	if verbose {
 		log.Println("Posting files to the App Catalog: " + uri)
 	}
@@ -20,12 +21,12 @@ func prepare(uri string, files map[string]string, config config.Config, verbose 
 		return
 	}
 
-	err = addAuthenticationHeader(req, config)
+	err = addAuthenticationHeader(req, config, logger)
 	return
 }
 
-func addAuthenticationHeader(req *http.Request, config config.Config) error {
-	token, err := auth.LoadAuthToken(config)
+func addAuthenticationHeader(req *http.Request, config config.Config, logger *appixLogger.Logger) error {
+	token, err := auth.LoadAuthToken(config, logger)
 
 	if err == nil {
 		req.Header.Set("Authorization", token.TokenType+" "+token.IdToken)

--- a/appcatalog/pushToCatalog.go
+++ b/appcatalog/pushToCatalog.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Travix-International/appix/appixLogger"
 	"github.com/Travix-International/appix/config"
 )
 
@@ -17,14 +18,14 @@ const (
 )
 
 // PushToCatalog pushes the specified app to the AppCatalog.
-func PushToCatalog(pushURI string, appManifestFile string, verbose bool, config config.Config) (uploadURI string, err error) {
+func PushToCatalog(pushURI string, appManifestFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (uploadURI string, err error) {
 	var req *http.Request
 	files := map[string]string{
 		"manifest": appManifestFile,
 	}
 
 	for attempt := 1; attempt <= config.MaxRetryAttempts; attempt++ {
-		if req, err = prepare(pushURI, files, config, verbose); err != nil {
+		if req, err = prepare(pushURI, files, config, verbose, logger); err != nil {
 			return "", err
 		}
 

--- a/appcatalog/submitToCatalog.go
+++ b/appcatalog/submitToCatalog.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Travix-International/appix/appixLogger"
 	"github.com/Travix-International/appix/config"
 )
 
@@ -18,7 +19,7 @@ type submitResponse struct {
 }
 
 // SubmitToCatalog submits the specified app to the AppCatalog.
-func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, verbose bool, config config.Config) (acceptanceQueryURL string, err error) {
+func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (acceptanceQueryURL string, err error) {
 	var req *http.Request
 	files := map[string]string{
 		"manifest": appManifestFile,
@@ -26,7 +27,7 @@ func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, v
 	}
 
 	for attempt := 1; attempt <= config.MaxRetryAttempts; attempt++ {
-		if req, err = prepare(submitURI, files, config, verbose); err != nil {
+		if req, err = prepare(submitURI, files, config, verbose, logger); err != nil {
 			return "", err
 		}
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -73,13 +73,9 @@ type ProfileBody struct {
 	Profile    Profile
 }
 
-var logger *appixLogger.Logger
-
 // LoadAuthToken checks if the user is already logged in, it tries to load the locally stored Authentication token, and refreshes it.
 // If the user is not logged in, it returns an error.
-func LoadAuthToken(config config.Config) (TokenBody, error) {
-	logger = appixLogger.NewAppixLogger(config.TravixLoggerUrl)
-
+func LoadAuthToken(config config.Config, logger *appixLogger.Logger) (TokenBody, error) {
 	firebaseAPIKey := config.FirebaseApiKey
 	authData, err := readAuthData(config.AuthFilePath)
 

--- a/cmd/appix/main.go
+++ b/cmd/appix/main.go
@@ -49,6 +49,14 @@ var running = make(chan bool)
 func main() {
 	parsedBuildDate, _ = time.Parse("Mon.January.2.2006.15:04:05.-0700.MST", buildDate)
 
+	// Context
+	config := makeConfig()
+
+	// appixLogger
+	logger := appixLogger.NewAppixLogger(config.TravixLoggerUrl)
+	logger.Start()
+	defer logger.Stop()
+
 	args := appix.GlobalArgs{}
 
 	// App
@@ -62,23 +70,17 @@ func main() {
 		Short('v').
 		BoolVar(&args.Verbose)
 
-	// Context
-	config := makeConfig()
-
-	// appixLogger
-	logger := appixLogger.NewAppixLogger(config.TravixLoggerUrl)
-	logger.Start()
+	log.Println("Registering commands")
 
 	appix.RegisterInit(app, config, &args)
 	appix.RegisterLogin(app, config, &args)
-	appix.RegisterPush(app, config, &args)
-	appix.RegisterSubmit(app, config, &args)
+	appix.RegisterPush(app, config, &args, logger)
+	appix.RegisterSubmit(app, config, &args, logger)
 	appix.RegisterVersion(app, config)
-	appix.RegisterWatch(app, config, &args)
-	appix.RegisterWhoami(app, config, &args)
+	appix.RegisterWatch(app, config, &args, logger)
+	appix.RegisterWhoami(app, config, &args, logger)
 
-	// kingpin config
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	app.Parse(os.Args[1:])
 }
 
 func makeConfig() config.Config {

--- a/init.go
+++ b/init.go
@@ -36,7 +36,7 @@ func RegisterInit(app *kingpin.Application, config config.Config, args *GlobalAr
 			// anyting special. The command line handling has already validated that the folder actually exists
 			isEmptyPath, err := isEmptyPath(appPathAbsolute)
 			if !isEmptyPath || err != nil {
-				log.Printf("The specified appPath '%s' does not appear to be an empty directory\n%v", appPathRelative, err)
+				log.Printf("The specified appPath '%s' does not appear to be an empty directory. Error: %v", appPathRelative, err)
 				return err
 			}
 

--- a/push.go
+++ b/push.go
@@ -22,7 +22,7 @@ const (
 )
 
 // RegisterPush registers the 'push' command.
-func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalArgs) {
+func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalArgs, logger *appixLogger.Logger) {
 	var (
 		appPath       string // path to the App folder
 		noBrowser     bool   // skip opening the site in the browser
@@ -32,7 +32,7 @@ func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalAr
 
 	command := app.Command("push", "Push the App in the specified folder.").
 		Action(func(parseContext *kingpin.ParseContext) error {
-			return push(config, appPath, noBrowser, waitInSeconds, localFrontend, args)
+			return push(config, appPath, noBrowser, waitInSeconds, localFrontend, args, logger)
 		})
 
 	command.Arg("appPath", "path to the App folder (default: current folder).").
@@ -52,10 +52,8 @@ func RegisterPush(app *kingpin.Application, config config.Config, args *GlobalAr
 		BoolVar(&localFrontend)
 }
 
-func push(config config.Config, appPath string, noBrowser bool, wait int, localFrontend bool, args *GlobalArgs) error {
+func push(config config.Config, appPath string, noBrowser bool, wait int, localFrontend bool, args *GlobalArgs, logger *appixLogger.Logger) error {
 	appPath, appName, appManifestFile, err := prepareAppUpload(appPath)
-
-	defer logger.Stop()
 
 	if err != nil {
 		log.Println("Could not prepare the app folder for uploading")
@@ -89,7 +87,7 @@ func push(config config.Config, appPath string, noBrowser bool, wait int, localF
 	rootURI := config.CatalogURIs[args.TargetEnv]
 	pushURI := fmt.Sprintf(pushTemplateURI, rootURI, appName, sessionID)
 
-	uploadURI, err := appcatalog.PushToCatalog(pushURI, appManifestFile, args.Verbose, config)
+	uploadURI, err := appcatalog.PushToCatalog(pushURI, appManifestFile, args.Verbose, config, logger)
 
 	if err != nil {
 		logger.AddMessageToQueue(appixLogger.LoggerNotification{

--- a/submit.go
+++ b/submit.go
@@ -11,20 +11,14 @@ import (
 	"github.com/Travix-International/appix/config"
 )
 
-var logger *appixLogger.Logger
-
 // RegisterSubmit registers the 'submit' command.
-func RegisterSubmit(app *kingpin.Application, config config.Config, args *GlobalArgs) {
-	logger = appixLogger.NewAppixLogger(config.TravixLoggerUrl)
-
+func RegisterSubmit(app *kingpin.Application, config config.Config, args *GlobalArgs, logger *appixLogger.Logger) {
 	const submitTemplateURI = "%s/apps/%s/submit"
 
 	var appPath string // path to the App folder
 
 	command := app.Command("submit", "Submits the App for review.").
 		Action(func(parseContext *kingpin.ParseContext) error {
-			defer logger.Stop()
-
 			environment := args.TargetEnv
 
 			if environment == "" {
@@ -58,7 +52,7 @@ func RegisterSubmit(app *kingpin.Application, config config.Config, args *Global
 			rootURI := config.CatalogURIs[environment]
 			submitURI := fmt.Sprintf(submitTemplateURI, rootURI, appName)
 
-			acceptanceQueryURLPath, err := appcatalog.SubmitToCatalog(submitURI, appManifestFile, zapFile, args.Verbose, config)
+			acceptanceQueryURLPath, err := appcatalog.SubmitToCatalog(submitURI, appManifestFile, zapFile, args.Verbose, config, logger)
 
 			if err != nil {
 				logger.AddMessageToQueue(appixLogger.LoggerNotification{

--- a/watch.go
+++ b/watch.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Travix-International/appix/appixLogger"
 	"github.com/Travix-International/appix/config"
 	"github.com/rjeczalik/notify"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -46,7 +47,7 @@ var (
 )
 
 // RegisterWatch registers the 'watch' command.
-func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalArgs) {
+func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalArgs, logger *appixLogger.Logger) {
 	var localFrontend bool
 
 	command := app.Command("watch", "Watches the current directory for changes, and pushes on any change.").
@@ -74,7 +75,7 @@ func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalA
 			livereload.StartServer()
 
 			// Immediately push once, and then start watching.
-			doPush(config, args, true, localFrontend, nil)
+			doPush(config, args, true, localFrontend, nil, logger)
 
 			livereload.SendReload()
 
@@ -115,12 +116,12 @@ func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalA
 
 					log.Println("File change detected, executing appix push.")
 
-					go doPush(config, args, false, localFrontend, pushDone)
+					go doPush(config, args, false, localFrontend, pushDone, logger)
 				case <-pushDone:
 					if watcherState == pushingAndGotEvent {
 						// A change event arrived while the previous push was happening, we push again.
 						watcherState = pushing
-						go doPush(config, args, false, localFrontend, pushDone)
+						go doPush(config, args, false, localFrontend, pushDone, logger)
 					} else {
 						watcherState = waiting
 						log.Println("Push done, watching for file changes.")
@@ -141,8 +142,8 @@ func RegisterWatch(app *kingpin.Application, config config.Config, args *GlobalA
 		BoolVar(&localFrontend)
 }
 
-func doPush(config config.Config, args *GlobalArgs, openBrowser bool, localFrontend bool, pushDone chan<- int) {
-	push(config, appPath, !openBrowser, 180, localFrontend, args)
+func doPush(config config.Config, args *GlobalArgs, openBrowser bool, localFrontend bool, pushDone chan<- int, logger *appixLogger.Logger) {
+	push(config, appPath, !openBrowser, 180, localFrontend, args, logger)
 
 	if !openBrowser {
 		livereload.SendReload()

--- a/whoami.go
+++ b/whoami.go
@@ -6,15 +6,16 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/Travix-International/appix/appixLogger"
 	"github.com/Travix-International/appix/auth"
 	"github.com/Travix-International/appix/config"
 )
 
 // RegisterWhoami registers the 'whoami' command.
-func RegisterWhoami(app *kingpin.Application, config config.Config, args *GlobalArgs) {
+func RegisterWhoami(app *kingpin.Application, config config.Config, args *GlobalArgs, logger *appixLogger.Logger) {
 	app.Command("whoami", "Displays logged in user's information").
 		Action(func(parseContext *kingpin.ParseContext) error {
-			authToken, err := auth.LoadAuthToken(config)
+			authToken, err := auth.LoadAuthToken(config, logger)
 
 			if err != nil {
 				fmt.Println("You are not logged in.\nYou can sign in by using 'appix login'.")


### PR DESCRIPTION
Replaced the singleton pattern with IoC: we're only creating the logger instance in `main.go`, from which we're passing it as an argument to all the functions which need it, and then we dispose it at the end.

This fixes the problem with the second push hanging when using `watch`, since we're not disposing the logger at the end of pushes any more.