### PR TITLE
Not retry appcatalog push/submit if status code != 500

### DIFF
--- a/appcatalog/error.go
+++ b/appcatalog/error.go
@@ -1,0 +1,16 @@
+package appcatalog
+
+import "fmt"
+
+type catalogError struct {
+	operation  string
+	statusCode int
+}
+
+func (err *catalogError) Error() string {
+	return fmt.Sprintf("%s failed, App Catalog returned status code %v\n", err.operation, err.statusCode)
+}
+
+func (err *catalogError) canRetry() bool {
+	return err.statusCode == 500 // SERVER ERROR
+}


### PR DESCRIPTION
Push/submit can only be re-tried if the status code = 400.  That's because sometimes an error occurs in the app catalog, but succeeds on second attempt.

If the error is either authentication error or a server error, it won't retry to push.