### PR TITLE
TR-13122 Increase timeouts (rebased)

### DIFF
--- a/appcatalog/pushToCatalog.go
+++ b/appcatalog/pushToCatalog.go
@@ -72,6 +72,11 @@ func doPush(req *http.Request, maxTimeoutValue time.Duration, verbose bool) (upl
 		return "", fmt.Errorf("Authentication error")
 	}
 
+	if res.StatusCode == 504 || res.StatusCode == 408 {
+		log.Printf("The AppCatalog was too long to respond (status code %v)", res.StatusCode)
+		return "", fmt.Errorf("Timeout error")
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	defer res.Body.Close()
 

--- a/appcatalog/pushToCatalog.go
+++ b/appcatalog/pushToCatalog.go
@@ -13,12 +13,8 @@ import (
 	"github.com/Travix-International/appix/config"
 )
 
-const (
-	timeout = time.Duration(10 * time.Second)
-)
-
 // PushToCatalog pushes the specified app to the AppCatalog.
-func PushToCatalog(pushURI string, appManifestFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (uploadURI string, err error) {
+func PushToCatalog(pushURI string, timeout int, appManifestFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (uploadURI string, err error) {
 	var req *http.Request
 	files := map[string]string{
 		"manifest": appManifestFile,
@@ -31,10 +27,7 @@ func PushToCatalog(pushURI string, appManifestFile string, verbose bool, config 
 
 		log.Printf("Pushing files to catalog. Attempt %v of %v\n", attempt, config.MaxRetryAttempts)
 
-		requestTimeout := float64(((attempt + 1) * config.MaxTimeoutValue) * 1000)
-		durationRequestTimeout := time.Duration(requestTimeout) * time.Millisecond
-
-		if uploadURI, err = doPush(req, durationRequestTimeout, verbose); err == nil {
+		if uploadURI, err = doPush(req, time.Duration(timeout)*time.Second, verbose); err == nil {
 			break
 		}
 

--- a/appcatalog/pushToCatalog.go
+++ b/appcatalog/pushToCatalog.go
@@ -73,7 +73,7 @@ func doPush(req *http.Request, maxTimeoutValue time.Duration, verbose bool) (upl
 	}
 
 	if res.StatusCode == 504 || res.StatusCode == 408 {
-		log.Printf("The AppCatalog was too long to respond (status code %v)", res.StatusCode)
+		log.Printf("The AppCatalog request timed out (status code %v)", res.StatusCode)
 		return "", fmt.Errorf("Timeout error")
 	}
 

--- a/appcatalog/pushToCatalog.go
+++ b/appcatalog/pushToCatalog.go
@@ -42,6 +42,8 @@ func PushToCatalog(pushURI string, appManifestFile string, verbose bool, config 
 			break
 		}
 
+		log.Printf("An error occured when trying to push the application: %s\n", err.Error())
+
 		if attempt < config.MaxRetryAttempts {
 			wait := math.Pow(2, float64(attempt-1)) * 1000
 			time.Sleep(time.Duration(wait) * time.Millisecond)

--- a/appcatalog/submitToCatalog.go
+++ b/appcatalog/submitToCatalog.go
@@ -74,6 +74,11 @@ func doSubmit(req *http.Request, maxTimeoutValue time.Duration, verbose bool) (a
 		return "", fmt.Errorf("Authentication error")
 	}
 
+	if res.StatusCode == 504 || res.StatusCode == 408 {
+		log.Printf("The AppCatalog was too long to respond (status code %v)", res.StatusCode)
+		return "", fmt.Errorf("Timeout error")
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	defer res.Body.Close()
 

--- a/appcatalog/submitToCatalog.go
+++ b/appcatalog/submitToCatalog.go
@@ -44,6 +44,8 @@ func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, v
 			break
 		}
 
+		log.Printf("An error occured when trying to submit the application: %s\n", err.Error())
+
 		if attempt < config.MaxRetryAttempts {
 			wait := math.Pow(2, float64(attempt-1)) * 1000
 			time.Sleep(time.Duration(wait) * time.Millisecond)

--- a/appcatalog/submitToCatalog.go
+++ b/appcatalog/submitToCatalog.go
@@ -33,7 +33,10 @@ func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, v
 
 		log.Printf("Submitting files to App Catalog. Attempt %v of %v\n", attempt, config.MaxRetryAttempts)
 
-		if acceptanceQueryURL, err = doSubmit(req, verbose); err == nil {
+		requestTimeout := float64(((attempt + 1) * config.MaxTimeoutValue) * 1000)
+		durationRequestTimeout := time.Duration(requestTimeout) * time.Millisecond
+
+		if acceptanceQueryURL, err = doSubmit(req, durationRequestTimeout, verbose); err == nil {
 			break
 		}
 
@@ -50,11 +53,13 @@ func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, v
 	return
 }
 
-func doSubmit(req *http.Request, verbose bool) (acceptanceQueryURL string, err error) {
+func doSubmit(req *http.Request, maxTimeoutValue time.Duration, verbose bool) (acceptanceQueryURL string, err error) {
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout: maxTimeoutValue,
 	}
+
 	res, err := client.Do(req)
+
 	if err != nil {
 		log.Println("Call to App Catalog failed!")
 		return "", err

--- a/appcatalog/submitToCatalog.go
+++ b/appcatalog/submitToCatalog.go
@@ -19,7 +19,7 @@ type submitResponse struct {
 }
 
 // SubmitToCatalog submits the specified app to the AppCatalog.
-func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (acceptanceQueryURL string, err error) {
+func SubmitToCatalog(submitURI string, timeout int, appManifestFile string, zapFile string, verbose bool, config config.Config, logger *appixLogger.Logger) (acceptanceQueryURL string, err error) {
 	var req *http.Request
 	files := map[string]string{
 		"manifest": appManifestFile,
@@ -33,10 +33,7 @@ func SubmitToCatalog(submitURI string, appManifestFile string, zapFile string, v
 
 		log.Printf("Submitting files to App Catalog. Attempt %v of %v\n", attempt, config.MaxRetryAttempts)
 
-		requestTimeout := float64(((attempt + 1) * config.MaxTimeoutValue) * 1000)
-		durationRequestTimeout := time.Duration(requestTimeout) * time.Millisecond
-
-		if acceptanceQueryURL, err = doSubmit(req, durationRequestTimeout, verbose); err == nil {
+		if acceptanceQueryURL, err = doSubmit(req, time.Duration(timeout)*time.Second, verbose); err == nil {
 			break
 		}
 

--- a/cmd/appix/main.go
+++ b/cmd/appix/main.go
@@ -68,7 +68,7 @@ func main() {
 		Short('v').
 		BoolVar(&args.Verbose)
 	app.Flag("timeout", "Set the maximum timeout for the request").
-		Default("5").
+		Default("10").
 		IntVar(&args.Timeout)
 
 	log.Println("Registering commands")

--- a/cmd/appix/main.go
+++ b/cmd/appix/main.go
@@ -42,6 +42,7 @@ var (
 	verbose          = false
 	localFrontend    = false
 	maxRetryAttempts = 5
+	maxTimeoutValue  = 5 // seconds
 )
 
 func main() {
@@ -110,6 +111,7 @@ func makeConfig() config.Config {
 
 		AuthServerPort:   "7001",
 		MaxRetryAttempts: maxRetryAttempts,
+		MaxTimeoutValue:  maxTimeoutValue,
 	}
 
 	return config

--- a/cmd/appix/main.go
+++ b/cmd/appix/main.go
@@ -42,7 +42,6 @@ var (
 	verbose          = false
 	localFrontend    = false
 	maxRetryAttempts = 5
-	maxTimeoutValue  = 5 // seconds
 )
 
 func main() {
@@ -68,6 +67,9 @@ func main() {
 	app.Flag("verbose", "Verbose mode.").
 		Short('v').
 		BoolVar(&args.Verbose)
+	app.Flag("timeout", "Set the maximum timeout for the request").
+		Default("5").
+		IntVar(&args.Timeout)
 
 	log.Println("Registering commands")
 
@@ -111,7 +113,6 @@ func makeConfig() config.Config {
 
 		AuthServerPort:   "7001",
 		MaxRetryAttempts: maxRetryAttempts,
-		MaxTimeoutValue:  maxTimeoutValue,
 	}
 
 	return config

--- a/config/config.go
+++ b/config/config.go
@@ -28,5 +28,4 @@ type Config struct {
 
 	AuthServerPort   string
 	MaxRetryAttempts int
-	MaxTimeoutValue  int
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,4 +28,5 @@ type Config struct {
 
 	AuthServerPort   string
 	MaxRetryAttempts int
+	MaxTimeoutValue  int
 }

--- a/globalArgs.go
+++ b/globalArgs.go
@@ -4,4 +4,5 @@ package appix
 type GlobalArgs struct {
 	Verbose   bool
 	TargetEnv string
+	Timeout   int
 }

--- a/push.go
+++ b/push.go
@@ -89,7 +89,7 @@ func push(config config.Config, appPath string, noBrowser bool, wait int, localF
 	rootURI := config.CatalogURIs[args.TargetEnv]
 	pushURI := fmt.Sprintf(pushTemplateURI, rootURI, appName, sessionID)
 
-	uploadURI, err := appcatalog.PushToCatalog(pushURI, appManifestFile, args.Verbose, config, logger)
+	uploadURI, err := appcatalog.PushToCatalog(pushURI, args.Timeout, appManifestFile, args.Verbose, config, logger)
 
 	if err != nil {
 		logger.AddMessageToQueue(appixLogger.LoggerNotification{

--- a/submit.go
+++ b/submit.go
@@ -52,7 +52,7 @@ func RegisterSubmit(app *kingpin.Application, config config.Config, args *Global
 			rootURI := config.CatalogURIs[environment]
 			submitURI := fmt.Sprintf(submitTemplateURI, rootURI, appName)
 
-			acceptanceQueryURLPath, err := appcatalog.SubmitToCatalog(submitURI, appManifestFile, zapFile, args.Verbose, config, logger)
+			acceptanceQueryURLPath, err := appcatalog.SubmitToCatalog(submitURI, args.Timeout, appManifestFile, zapFile, args.Verbose, config, logger)
 
 			if err != nil {
 				logger.AddMessageToQueue(appixLogger.LoggerNotification{


### PR DESCRIPTION
__This is a rebased PR.  Original PR [#57](https://github.com/Travix-International/appix/pull/57) by @jackTheRipper__

----

**Do**

Increase the request timeout on each `submit` or `push` retry

The script adds 5 seconds on each retries.

It starts with a first attempt with a timeout of 10 seconds. The timeout increase to 30 seconds for the last try.
