### PR TITLE
Fix: vet indicates issue in body being used before we check for error

### DIFF
--- a/auth/profile.go
+++ b/auth/profile.go
@@ -25,11 +25,11 @@ func FetchDeveloperProfile(tokenBody TokenBody, developerProfileURL string) (Pro
 	profileReq.Header.Set("Authorization", tokenType+" "+tokenValue)
 	profileRes, profileResErr := profileClient.Do(profileReq)
 
-	defer profileRes.Body.Close()
-
 	if profileResErr != nil {
 		return ProfileBody{}, profileResErr
 	}
+
+	defer profileRes.Body.Close()
 
 	profileBody := ProfileBody{}
 	err := json.NewDecoder(profileRes.Body).Decode(&profileBody)


### PR DESCRIPTION
Fix: vet indicates issue in body being used before we check for errors. Body could be nil, after all.