### PR TITLE
Added some suggested Makefile additions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,26 @@
+.PHONY: test vet lint testonly race cover
+
 GITHUB_API_TOKEN := ""
 
 changelog:
 	github_changelog_generator -t $(GITHUB_API_TOKEN)
 	cat CHANGELOG.md | awk 'skip == 0 {print}; $$0 ~ "appix-1.0.1.1" {skip = 1}' | tee CHANGELOG.md >> /dev/null 2>&1 && echo "Generated CHANGELOG.md"
+
+
+test: vet testonly
+
+vet:
+	go vet `go list ./... | grep -v /vendor/`
+
+lint:
+	golint `go list ./... | grep -v /vendor/`
+
+testonly:
+	go test -cover `go list ./... | grep -v /vendor/`
+
+race:
+	go test -race `go list ./... | grep -v /vendor/`
+
+cover:
+	echo Covering package ./$(PKG)
+	go test -coverprofile=cover.out ./$(PKG) && go tool cover -html=cover.out


### PR DESCRIPTION
As a developer
In order to support my lazy nature
I wish to have some basic commands ready to go

`make test` will vet and test your code
`PKG=auth make cover` will show you line-by-line code coverage
`make race` will test for race conditions.
The others are easy to figure out.

(New PR due to CI pipeline not working from forked repo at the moment)