### PR TITLE
Increased coverage on logger package + minor tweaks

### DIFF
--- a/appixLogger/logger_test.go
+++ b/appixLogger/logger_test.go
@@ -1,0 +1,98 @@
+package appixLogger_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"encoding/json"
+
+	"github.com/Travix-International/appix/appixLogger"
+	"github.com/alecthomas/assert"
+)
+
+// TestAppixLogger_StartStop tests the start & stop of the logger without logging statements
+func TestAppixLogger_StartStop(t *testing.T) {
+	url := "http://localhost:1/nope"
+	sut := appixLogger.NewAppixLogger(url)
+
+	sut.Start()
+	sut.Stop()
+}
+
+// TestAppixLogger_LogToHttp makes sure that the HTTP target is called ad the default context is added
+func TestAppixLogger_LogToHttp_InfoIncludesDefaultContext(t *testing.T) {
+	// Set us up to receive logging events
+	logServer := &mockHttpLogServer{}
+	server := httptest.NewServer(logServer)
+	sut := appixLogger.NewAppixLogger(server.URL)
+
+	sut.Start()
+	sut.AddMessageToQueue(appixLogger.LoggerNotification{
+		Level:    appixLogger.LevelInfo,
+		LogEvent: "SomeEvent",
+		Message:  "SomeMessage",
+	})
+	sut.Stop()
+	server.Close()
+
+	// Check details of the message that got logged
+	assert.Equal(t, 1, logServer.LogCount)
+	logMessage := make(map[string]interface{})
+	err := json.Unmarshal(logServer.Bodies[0], &logMessage)
+	assert.Nil(t, err)
+	assert.Equal(t, "Info", logMessage["level"].(string))
+	assert.Equal(t, "SomeEvent", logMessage["event"].(string))
+	assert.Equal(t, "SomeMessage", logMessage["message"].(string))
+	assert.Equal(t, "SomeEvent", logMessage["messageType"].(string))
+	assert.Equal(t, "core", logMessage["applicationgroup"].(string))
+	assert.Equal(t, "appix", logMessage["applicationname"].(string))
+}
+
+// TestAppixLogger_LogToHttp makes sure that the HTTP target is called ad the default context is added
+func TestAppixLogger_LogToHttp_ErrorIncludesDefaultContext(t *testing.T) {
+	// Set us up to receive logging events
+	logServer := &mockHttpLogServer{}
+	server := httptest.NewServer(logServer)
+	sut := appixLogger.NewAppixLogger(server.URL)
+
+	sut.Start()
+	sut.AddMessageToQueue(appixLogger.LoggerNotification{
+		Level:    appixLogger.LevelError,
+		LogEvent: "SomeEvent",
+		Message:  "SomeMessage",
+	})
+	sut.Stop()
+	server.Close()
+
+	// Check details of the message that got logged
+	assert.Equal(t, 1, logServer.LogCount)
+	logMessage := make(map[string]interface{})
+	err := json.Unmarshal(logServer.Bodies[0], &logMessage)
+	assert.Nil(t, err)
+	assert.Equal(t, "Error", logMessage["level"].(string))
+	assert.Equal(t, "SomeEvent", logMessage["event"].(string))
+	assert.Equal(t, "SomeMessage", logMessage["message"].(string))
+	assert.Equal(t, "SomeEvent", logMessage["messageType"].(string))
+	assert.Equal(t, "core", logMessage["applicationgroup"].(string))
+	assert.Equal(t, "appix", logMessage["applicationname"].(string))
+}
+
+type mockHttpLogServer struct {
+	LogCount int
+	Bodies   [][]byte
+}
+
+func (m *mockHttpLogServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	buf := bytes.NewBuffer(make([]byte, 0, r.ContentLength))
+	_, readErr := buf.ReadFrom(r.Body)
+	if readErr != nil {
+		panic("Missing content")
+	}
+	body := buf.Bytes()
+
+	m.Bodies = append(m.Bodies, body)
+	m.LogCount++
+}


### PR DESCRIPTION
This PR is mainly intended to increase code coverage to 96% on the `appixLogger` package.

While writing, I also changed the following in the actual code:
* I introduced convenience constants for the levels. Instead of `"error"` you can now do `logger.LevelError`
* The `Logger` was exposing some channels and other stuff that is an implementation detail to the struct. I unexposed them.
* I added an `AppixLogger` interface that could be used by other components to decouple themselves from the logger if they want to. Note that I explicitly did not add Start/Stop to this interface.
* Our channels are unbuffered. I assume that is intentional, so I documented it.

Also note: I haven't changed the other code to use the convenience interface/constants. Could do so.