### PR TITLE
Scaffold supports other templates and read from new repo

### DIFF
--- a/init.go
+++ b/init.go
@@ -14,8 +14,9 @@ import (
 // RegisterInit registers the 'init' command.
 func RegisterInit(app *kingpin.Application, config config.Config, args *GlobalArgs) {
 	var appPath string
+	var templateName string
 
-	command := app.Command("init", "Scaffold a new application into the specified folder").
+	command := app.Command("init", "Scaffold a new application into the specified folder, using the specified template.").
 		Action(func(parseContext *kingpin.ParseContext) error {
 			// grab the absolute path
 			appPathRelative := appPath
@@ -41,7 +42,7 @@ func RegisterInit(app *kingpin.Application, config config.Config, args *GlobalAr
 			}
 
 			// Scaffold
-			err = scaffoldNewApp(appPathAbsolute, args.Verbose)
+			err = scaffoldNewApp(appPathAbsolute, templateName, args.Verbose)
 			if err != nil {
 				return err
 			}
@@ -54,6 +55,10 @@ func RegisterInit(app *kingpin.Application, config config.Config, args *GlobalAr
 	command.Arg("appPath", "Path to an empty folder. (default: current folder)").
 		Default(".").
 		ExistingDirVar(&appPath)
+
+	command.Arg("template", "Name of the template to use. (default: 'default')").
+		Default("default").
+		StringVar(&templateName)
 }
 
 func isEmptyPath(appPath string) (bool, error) {

--- a/scaffold.go
+++ b/scaffold.go
@@ -39,7 +39,7 @@ func scaffoldNewApp(appPath string, verbose bool) error {
 }
 
 func applyTemplate(appPath string) error {
-	helloWorldTemplateURL := "https://raw.githubusercontent.com/Travix-International/travix-fireball-app-templates/master/HelloWorldTemplate.zip"
+	helloWorldTemplateURL := "https://github.com/Travix-International/travix-fireball-app-templates/archive/master.zip"
 
 	tempFolder, err := ioutil.TempDir("", "appix")
 	if err != nil {

--- a/scaffold.go
+++ b/scaffold.go
@@ -2,6 +2,8 @@ package appix
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -10,10 +12,10 @@ import (
 	"path/filepath"
 )
 
-func scaffoldNewApp(appPath string, verbose bool) error {
+func scaffoldNewApp(appPath, templateName string, verbose bool) error {
 	// Apply the template
 	log.Print("Scaffolding the application files...")
-	err := applyTemplate(appPath)
+	err := applyTemplate(appPath, templateName)
 	if err != nil {
 		log.Printf("Failed to apply template")
 		return err
@@ -38,8 +40,10 @@ func scaffoldNewApp(appPath string, verbose bool) error {
 	return nil
 }
 
-func applyTemplate(appPath string) error {
-	helloWorldTemplateURL := "https://github.com/Travix-International/travix-fireball-app-templates/archive/master.zip"
+func applyTemplate(appPath, templateName string) error {
+	helloWorldTemplateURL := "https://github.com/Travix-International/travix-appix-templates/archive/master.zip"
+	zipSubDirectory := "travix-appix-templates-master"
+	zipSubDirectory = fmt.Sprintf("%s/%s/", zipSubDirectory, templateName)
 
 	tempFolder, err := ioutil.TempDir("", "appix")
 	if err != nil {
@@ -54,7 +58,7 @@ func applyTemplate(appPath string) error {
 
 	defer out.Close()
 
-	log.Println("Downloading template from " + helloWorldTemplateURL)
+	log.Printf("Downloading template '%s' from %s\n", templateName, helloWorldTemplateURL)
 
 	// Download the template.
 	resp, err := http.Get(helloWorldTemplateURL)
@@ -70,9 +74,16 @@ func applyTemplate(appPath string) error {
 	}
 
 	// Unzip the template and do some basic replacements.
-	err = extractZip(tempFile, appPath)
+	var fileCount int
+	fileCount, err = extractZip(tempFile, appPath, zipSubDirectory)
 	if err != nil {
 		return err
+	}
+
+	if fileCount <= 0 {
+		errorText := fmt.Sprintf("Template '%s' does not exist", templateName)
+		log.Print(errorText)
+		return errors.New(errorText)
 	}
 
 	appName := filepath.Base(appPath)


### PR DESCRIPTION
With this PR, the templates will now be read from the new location: https://github.com/Travix-International/travix-appix-templates There we can have folders, where each folder is a template for appix. Right now, there's only the `default` template, which `appix init` uses by default.

We're downloading the zip now through the built-in GitHub 'download as zip'. This also means that in the zip file we'll need to look for the right sub-directory that contains our example. This is currently done through a simple comparison of the path within the zip.

By counting files, we will report if the template does not exist (0 files extracted). There is no functionality to list available templates.