### PR TITLE
Introduce the ability to override the dev server URL when pushing an app

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ export TRAVIX_LOGGER_URL=""
 export TRAVIX_DEVELOPER_PROFILE_URL=""
 ```
 
+### Using a custom dev server
+
+If we want to override the dev server to which `appix` is pushing an application under development, we have to add the `"DevServerOverride"` property to the `.appixDevSettings` file in the root folder of our application.
+
+```
+{
+  ...
+  "DevServerOverride": "https://my-dev-server.example.com"
+}
+```
+
 ### Build
 
 Running this would generate `./bin/appix-mac` (if you are on macOS):

--- a/devSettings.go
+++ b/devSettings.go
@@ -17,7 +17,8 @@ import (
 */
 
 type DevelopmentSettings struct {
-	SessionID string // This would be the session ID that the user will use the push/preview his changes
+	SessionID         string // This would be the session ID that the user will use the push/preview his changes.
+	DevServerOverride string // When pushing an app, the default dev server returned by the app catalog can be overwritten with this.
 }
 
 func readDevelopmentSettings(appPath string, verbose bool) (*DevelopmentSettings, error) {


### PR DESCRIPTION
A quick change I did today: added a feature to be able to use a different dev server then what's returned by the catalog, by adding this to our `.appixDevSettings` file:
```
{
  ...
  "DevServerOverride": "https://fireball-dev-other.travix.com"
}
```
Currently it'll be handy for us to test a different server, in the future we can make this an actual `appix` command of course.