### PR TITLE
Fail safe if app catalog does not return valid poll URI

### DIFF
--- a/appcatalog/frontendUpload.go
+++ b/appcatalog/frontendUpload.go
@@ -46,6 +46,10 @@ func UploadToFrontend(uploadURI string, zapFile string, appName string, sessionI
 		logServerResponse(response)
 	}
 
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Uploading failed, the frontend returned status code %v", response.StatusCode)
+	}
+
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Println("Error reading response from the frontend.")
@@ -62,8 +66,6 @@ func UploadToFrontend(uploadURI string, zapFile string, appName string, sessionI
 		return "", err
 	}
 
-	log.Printf("Express frontend returned status code %v.", response.StatusCode)
-
 	// The frontend returns a link which can be used to poll the upload status.
 	// {
 	//   "links": {
@@ -76,11 +78,7 @@ func UploadToFrontend(uploadURI string, zapFile string, appName string, sessionI
 		return "", fmt.Errorf("Uploading failed, the app catalog did not return a valid response")
 	}
 
-	if response.StatusCode == http.StatusOK {
-		log.Println("The app has been uploaded to the frontend successfully.")
-	} else {
-		return "", fmt.Errorf("Uploading failed, the frontend returned status code %v", response.StatusCode)
-	}
+	log.Println("The app has been uploaded to the frontend successfully.")
 
 	return progressUri, nil
 }

--- a/appcatalog/frontendUpload_test.go
+++ b/appcatalog/frontendUpload_test.go
@@ -20,7 +20,7 @@ func TestUploadToFrontend(t *testing.T) {
 	pollURI, err := UploadToFrontend(testServer.URL, "../mocks/mock.js", "test", "132-321", false)
 
 	if err != nil {
-		t.Fatalf("TestUpladToFrontend failed. Details: %s\n", err.Error())
+		t.Fatalf("UploadToFrontend failed. Details: %s\n", err.Error())
 	} else {
 		if pollURI == "https://fireball-dev.travix.com/upload/progress?sessionId=123" {
 			t.Log("The test was successful")
@@ -42,7 +42,7 @@ func TestUploadToFrontendFail(t *testing.T) {
 	pollURI, err := UploadToFrontend(testServer.URL, "../mocks/mock.js", "test", "132-321", false)
 
 	if err != nil {
-		t.Logf("TestUpladToFrontend failed. Details: %s\n", err.Error())
+		t.Logf("UploadToFrontend failed. Details: %s\n", err.Error())
 	} else {
 		t.Fatalf("UploadToFrontend must throw an error. Output: %s\n", pollURI)
 	}
@@ -60,7 +60,25 @@ func TestUploadToFrontendBadPath(t *testing.T) {
 	pollURI, err := UploadToFrontend(testServer.URL, "mock.js", "test", "132-321", false)
 
 	if err != nil {
-		t.Logf("TestUpladToFrontend failed. Details: %s\n", err.Error())
+		t.Logf("UploadToFrontend failed. Details: %s\n", err.Error())
+	} else {
+		t.Fatalf("UploadToFrontend must throw an error. Output: %s\n", pollURI)
+	}
+}
+
+func TestCatalogResponse_MissingProgressUri(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		bodyBytes := []byte(`{}`)
+		w.Write(bodyBytes)
+	}))
+
+	defer testServer.Close()
+
+	pollURI, err := UploadToFrontend(testServer.URL, "mock.js", "test", "132-321", false)
+
+	if err != nil {
+		t.Logf("UploadToFrontend failed. Details: %s\n", err.Error())
 	} else {
 		t.Fatalf("UploadToFrontend must throw an error. Output: %s\n", pollURI)
 	}


### PR DESCRIPTION
Just a quick fail safe for the appcatalog response, we want to verify that the unmarshalled json response is actually valid regardless of the status code.  If it does not contain the `links.progress` property, then we don't call it and prevent an `stream error: stream ID 1; INTERNAL_ERROR`.