### PR TITLE
Added certContent and keyContent keys go config helper and to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,8 @@ APP_LDFLAGS="-s
 -X main.travixFirebaseRefreshTokenUrl=$TRAVIX_FIREBASE_REFRESH_TOKEN_URL
 -X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL
 -X main.travixLoggerUrl=$TRAVIX_LOGGER_URL
--X livereload.certContent=$TRAVIX_CERT_CONTENT
--X livereload.keyContent=$TRAVIX_KEY_CONTENT"
+-X github.com/Travix-International/appix/livereload.certContent=$TRAVIX_CERT_CONTENT
+-X github.com/Travix-International/appix/livereload.keyContent=$TRAVIX_KEY_CONTENT"
 
 # run the tests
 go test $(go list ./... | grep -v /vendor/)

--- a/firebase-config-helper.js
+++ b/firebase-config-helper.js
@@ -6,11 +6,15 @@ var config = {
     databaseURL: "https://fireball-development.firebaseio.com",
     projectId: "fireball-development",
     storageBucket: "fireball-development.appspot.com",
-    messagingSenderId: "445151709427"
+    messagingSenderId: "445151709427",
+    certContent: "DummyCertificateContent",
+    keyContent: "DummyKeyContent"
   };
 
 console.log(
 `For PowerShell:
+$env:TRAVIX_CERT_CONTENT='${config.certContent}'
+$env:TRAVIX_KEY_CONTENT='${config.keyContent}'
 $env:TRAVIX_FIREBASE_API_KEY='${config.apiKey}'
 $env:TRAVIX_FIREBASE_DATABASE_URL='${config.databaseURL}'
 $env:TRAVIX_FIREBASE_STORAGE_BUCKET='${config.storageBucket}'
@@ -21,6 +25,8 @@ $env:TRAVIX_DEVELOPER_PROFILE_URL='https://developerprofile.${config.projectId.e
 $env:TRAVIX_LOGGER_URL='https://frogger.travix.com/'
 
 For bash:
+TRAVIX_CERT_CONTENT='${config.certContent}'
+TRAVIX_KEY_CONTENT='${config.keyContent}'
 TRAVIX_FIREBASE_API_KEY='${config.apiKey}'
 TRAVIX_FIREBASE_DATABASE_URL='${config.databaseURL}'
 TRAVIX_FIREBASE_STORAGE_BUCKET='${config.storageBucket}'

--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -21,7 +21,7 @@ var (
 )
 
 func base64Decode(src string) []byte {
-	val, err := base64.StdEncoding.DecodeString(certContent)
+	val, err := base64.StdEncoding.DecodeString(src)
 
 	if err != nil {
 		log.Fatalf("An error occured while decoding the value. Details: %s\n", err.Error())


### PR DESCRIPTION
Fix to the certificate and key content to be able to run the livereload feature on **appix watch** without any errors
Original Story: https://travix.atlassian.net/browse/TR-13543