### PR TITLE
Explictly set newer TLS version

### DIFF
--- a/appixinstall.ps1
+++ b/appixinstall.ps1
@@ -105,6 +105,8 @@ Param(
 
 Write-Output "Starting the Appix ADK installation"
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $appixVersion = $env:APPIX_VERSION
 if ([string]::IsNullOrEmpty($appixVersion)){
   # Determine the latest version


### PR DESCRIPTION
Probably github.com made their TLS versions more strict, because without this change the install failed with
```
The request was aborted: Could not create SSL/TLS secure channel.
```